### PR TITLE
feat: Add DataRestriction gRPC interface and add isPublisherNamespace flag in existing gRPC interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - 2023-08-11
+## [1.0.0] - 2023-08-29
 ### Added
 - Initial GDPR Java SDK implementation

--- a/README.md
+++ b/README.md
@@ -3,11 +3,12 @@
 GDPR SDK for integrating Java services with AGS (AccelByte Gaming Services) GDPR service.
 
 This GDPR SDK could be used by participant services to integrate into AGS GDPR workflow.
-There are 2 GDPR workflow that this GDPR SDK supported:
+There are 3 GDPR workflow that this GDPR SDK supported:
 1. Right to data portability
 2. Right to erasure (right to be forgotten)
+3. Right to restrict processing
 
-The participant services will hook their _**concrete GDPRHandler implementation**_ (that contains 2 functionalities above) into this GDPR SDK.
+The participant services will hook their _**concrete GDPRHandler implementation**_ (that contains 3 functionalities above) into this GDPR SDK.
 
 Under the hood, this GDPR SDK was using gRPC protocol for communication with AGS GDPR service:
 
@@ -51,7 +52,7 @@ Create new class to implement [GDPRHandler](src/main/java/net/accelbyte/gdpr/sdk
 ```java
 public class MyGDPRHandler implements GDPRHandler {
     @Override
-    public DataGenerationResult ProcessDataGeneration(String namespace, String userId) {
+    public DataGenerationResult ProcessDataGeneration(String namespace, String userId, boolean isPublisherNamespace) {
         log.info("collecting user data...");
 
         // your implementation here...
@@ -64,9 +65,16 @@ public class MyGDPRHandler implements GDPRHandler {
     }
 
     @Override
-    public void ProcessDataDeletion(String namespace, String userId) {
+    public void ProcessDataDeletion(String namespace, String userId, boolean isPublisherNamespace) {
         log.info("deleting user data...");
         
+        // your implementation here...
+    }
+    
+    @Override
+    public void ProcessDataRestriction(String namespace, String userId, boolean restrict, boolean isPublisherNamespace) {
+        log.info("restrict processing user data...");
+
         // your implementation here...
     }
 }

--- a/src/main/java/net/accelbyte/gdpr/sdk/GDPRHandler.java
+++ b/src/main/java/net/accelbyte/gdpr/sdk/GDPRHandler.java
@@ -22,17 +22,32 @@ public interface GDPRHandler {
      *    transaction: transactionData
      *  }
      *
-     * @param namespace namespace of user
-     * @param userId    user id
+     * @param namespace             namespace of user
+     * @param userId                user id
+     * @param isPublisherNamespace  indicate whether the "namespace" is a publisher namespace or game namespace
      * @return DataGenerationResult object
      */
-    DataGenerationResult ProcessDataGeneration(String namespace, String userId);
+    DataGenerationResult ProcessDataGeneration(String namespace, String userId, boolean isPublisherNamespace);
 
     /**
      * Process data deletion for the requested user.
      *
-     * @param namespace namespace of user
-     * @param userId    user id
+     * @param namespace             namespace of user
+     * @param userId                user id
+     * @param isPublisherNamespace  indicate whether the "namespace" is a publisher namespace or game namespace
      */
-    void ProcessDataDeletion(String namespace, String userId);
+    void ProcessDataDeletion(String namespace, String userId, boolean isPublisherNamespace);
+
+    /**
+     * Process data restriction for the requested user.
+     *
+     * This process will ensure the personal data associated with disabled account
+     * ceased to be available to other users.
+     *
+     * @param namespace             namespace of user
+     * @param userId                user id
+     * @param restrict              restrict or not
+     * @param isPublisherNamespace  indicate whether the "namespace" is a publisher namespace or game namespace
+     */
+    void ProcessDataRestriction(String namespace, String userId, boolean restrict, boolean isPublisherNamespace);
 }

--- a/src/main/proto/gdpr.proto
+++ b/src/main/proto/gdpr.proto
@@ -22,12 +22,21 @@ service GDPR {
    */
   rpc DataDeletion(DataDeletionRequest) returns (DataDeletionResponse) {};
 
+  /**
+   Data Restriction.
+
+   Used to inform registered service when specific IAM account was disabled,
+   So that the service could ensure the personal data associated with disabled account ceased to be available to other users.
+   */
+  rpc DataRestriction(DataRestrictionRequest) returns (DataRestrictionResponse) {};
+
 }
 
 message DataGenerationRequest {
   string namespace = 1; // namespace of user
   string userId = 2; // user id
   string uploadUrl = 3; // upload url for uploading the generated file into AccelByte GDPR Service storage
+  bool isPublisherNamespace = 4; // indicate whether the "namespace" is a publisher namespace or game namespace
 }
 
 message DataGenerationResponse {
@@ -38,9 +47,22 @@ message DataGenerationResponse {
 message DataDeletionRequest {
   string namespace = 1; // namespace of user
   string userId = 2; // user id
+  bool isPublisherNamespace = 3; // indicate whether the "namespace" is a publisher namespace or game namespace
 }
 
 message DataDeletionResponse {
   bool success = 1; // indicate data deletion was success
   string message = 2; // message from data deletion process
+}
+
+message DataRestrictionRequest {
+  string namespace = 1; // namespace of user
+  string userId = 2; // user id
+  bool restrict = 3; // restrict or not
+  bool isPublisherNamespace = 4; // indicate whether the "namespace" is a publisher namespace or game namespace
+}
+
+message DataRestrictionResponse {
+  bool success = 1; // indicate restrict processing was success
+  string message = 2; // message from restrict processing
 }


### PR DESCRIPTION
1. Add `DataRestriction` gRPC interface to support Restrict Processing workflow
2. Add `isPublisherNamespace` flag in existing gRPC interfaces (`DataGeneration` and `DataDeletion`)